### PR TITLE
Update terraform_azure

### DIFF
--- a/vantiq-cloud-infra-operations/terraform_azure/env-dev/main.tf
+++ b/vantiq-cloud-infra-operations/terraform_azure/env-dev/main.tf
@@ -261,8 +261,7 @@ module "aks" {
   # "Standard_E4s_v3" (4vCPU + 32GiB) - equivalent to R5.xlarge
   # "Standard_B2S" (2vCPU + 4GiB)- equivalent to T3.medium
   # "Standard_E2_v3" (4vCPU + 32GiB) -  equivalent to M5.large
-  # availability_zones = [1, 2, 3]
-  availability_zones = [3]
+  availability_zones = [1]
   vantiq_node_pool_vm_size = "Standard_F4s_v2"
   vantiq_node_pool_node_count = 1
   vantiq_node_pool_node_ephemeral_os_disk = true

--- a/vantiq-cloud-infra-operations/terraform_azure/env-dev/main.tf
+++ b/vantiq-cloud-infra-operations/terraform_azure/env-dev/main.tf
@@ -224,7 +224,7 @@ module "aks" {
   depends_on = [module.vpc]
 
   # kubernetes version
-  kubernetes_version = "1.19.11"
+  kubernetes_version = "1.22.11"
 
   # enable private cluster
   private_cluster_enabled = false
@@ -261,7 +261,8 @@ module "aks" {
   # "Standard_E4s_v3" (4vCPU + 32GiB) - equivalent to R5.xlarge
   # "Standard_B2S" (2vCPU + 4GiB)- equivalent to T3.medium
   # "Standard_E2_v3" (4vCPU + 32GiB) -  equivalent to M5.large
-  availability_zones = [1, 2, 3]
+  # availability_zones = [1, 2, 3]
+  availability_zones = [3]
   vantiq_node_pool_vm_size = "Standard_F4s_v2"
   vantiq_node_pool_node_count = 1
   vantiq_node_pool_node_ephemeral_os_disk = true

--- a/vantiq-cloud-infra-operations/terraform_azure/env-prod/main.tf
+++ b/vantiq-cloud-infra-operations/terraform_azure/env-prod/main.tf
@@ -226,7 +226,7 @@ module "aks" {
   depends_on = [module.vpc]
 
   # kubernetes version
-  kubernetes_version = "1.19.11"
+  kubernetes_version = "1.22.11"
 
   # enable private cluster
   private_cluster_enabled = false

--- a/vantiq-cloud-infra-operations/terraform_azure/env-template/main.tf
+++ b/vantiq-cloud-infra-operations/terraform_azure/env-template/main.tf
@@ -204,7 +204,7 @@ module "aks" {
   depends_on = [module.vpc]
 
   # kubernetes version
-  kubernetes_version = "1.19.11"
+  kubernetes_version = "1.22.11"
 
   # enable private cluster
   private_cluster_enabled = false

--- a/vantiq-cloud-infra-operations/terraform_azure/modules/aks/aks.tf
+++ b/vantiq-cloud-infra-operations/terraform_azure/modules/aks/aks.tf
@@ -45,15 +45,15 @@ resource "azurerm_kubernetes_cluster" "aks-vantiq" {
   }
 
   default_node_pool {
-    name       = "vantiqnp"
-    node_count = var.vantiq_node_pool_node_count
-    vm_size    = var.vantiq_node_pool_vm_size
-    os_disk_type = var.vantiq_node_pool_node_ephemeral_os_disk ? "Ephemeral" : null
-    os_disk_size_gb = var.vantiq_node_pool_node_ephemeral_os_disk ? 64 : null
+    name       = "keycloaknp"
+    node_count = var.keycloak_node_pool_node_count
+    vm_size    = var.keycloak_node_pool_vm_size
+    os_disk_type = var.keycloak_node_pool_node_ephemeral_os_disk ? "Ephemeral" : null
+    os_disk_size_gb = var.keycloak_node_pool_node_ephemeral_os_disk ? 64 : null
     vnet_subnet_id = var.aks_node_subnet_id
     availability_zones = var.availability_zones
     node_labels = {
-      "vantiq.com/workload-preference" = "compute"
+      "vantiq.com/workload-preference" = "shared"
     }
     orchestrator_version = var.kubernetes_version
   }
@@ -89,12 +89,14 @@ resource "azurerm_kubernetes_cluster" "aks-vantiq" {
   tags = var.tags
 }
 
-/*
+
 resource "azurerm_kubernetes_cluster_node_pool" "vantiqnp" {
-  count = var.mongodb_node_pool_node_count == 0 ? 0 : 1
+  count = var.vantiq_node_pool_node_count == 0 ? 0 : 1
   name                  = "vantiqnp"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks-vantiq.id
   vm_size               = var.vantiq_node_pool_vm_size
+  os_disk_type = var.vantiq_node_pool_node_ephemeral_os_disk ? "Ephemeral" : null
+  os_disk_size_gb = var.vantiq_node_pool_node_ephemeral_os_disk ? 64 : null
   node_count            = var.vantiq_node_pool_node_count
   vnet_subnet_id        = var.aks_node_subnet_id
   availability_zones    = var.availability_zones
@@ -103,8 +105,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "vantiqnp" {
   node_labels = {
     "vantiq.com/workload-preference" = "compute"
   }
+  orchestrator_version = var.kubernetes_version
 }
-*/
+
 
 resource "azurerm_kubernetes_cluster_node_pool" "mongodbnp" {
   count = var.mongodb_node_pool_node_count == 0 ? 0 : 1
@@ -138,24 +141,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "userdbnp" {
 
   node_labels = {
     "vantiq.com/workload-preference" = "userdb"
-  }
-  orchestrator_version = var.kubernetes_version
-}
-
-resource "azurerm_kubernetes_cluster_node_pool" "keycloaknp" {
-  count = var.keycloak_node_pool_node_count == 0 ? 0 : 1
-  name                  = "keycloaknp"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks-vantiq.id
-  vm_size               = var.keycloak_node_pool_vm_size
-  os_disk_type          = var.keycloak_node_pool_node_ephemeral_os_disk ? "Ephemeral" : null
-  os_disk_size_gb       = var.keycloak_node_pool_node_ephemeral_os_disk ? 64 : null
-  node_count            = var.keycloak_node_pool_node_count
-  vnet_subnet_id        = var.aks_node_subnet_id
-  availability_zones    = var.availability_zones
-  tags                  = var.tags
-
-  node_labels = {
-    "vantiq.com/workload-preference" = "shared"
   }
   orchestrator_version = var.kubernetes_version
 }

--- a/vantiq-cloud-infra-operations/terraform_azure/modules/aks/aks.tf
+++ b/vantiq-cloud-infra-operations/terraform_azure/modules/aks/aks.tf
@@ -154,7 +154,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "grafananp" {
   os_disk_size_gb       = var.grafana_node_pool_node_ephemeral_os_disk ? 64 : null
   node_count            = var.grafana_node_pool_node_count
   vnet_subnet_id        = var.aks_node_subnet_id
-  availability_zones    = var.availability_zones
+  availability_zones    = [var.availability_zones[0]]
   tags                  = var.tags
 
   node_labels = {
@@ -172,7 +172,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "metricsnp" {
   os_disk_size_gb       = var.metrics_node_pool_node_ephemeral_os_disk ? 64 : null
   node_count            = var.metrics_node_pool_node_count
   vnet_subnet_id        = var.aks_node_subnet_id
-  availability_zones    = var.availability_zones
+  availability_zones    = [var.availability_zones[0]]
   tags                  = var.tags
 
   node_labels = {

--- a/vantiq-cloud-infra-operations/terraform_azure/modules/aks/output.tf
+++ b/vantiq-cloud-infra-operations/terraform_azure/modules/aks/output.tf
@@ -55,11 +55,11 @@ output "aks_linux_ssh_key" {
 }
 
 output "aks_nodegroup_vantiq_vm_size" {
-  value = azurerm_kubernetes_cluster.aks-vantiq.default_node_pool[0].vm_size
+  value = var.vantiq_node_pool_node_count == 0 ? "N/A" : azurerm_kubernetes_cluster_node_pool.vantiqnp[0].vm_size
 }
 
 output "aks_nodegroup_vantiq_node_count" {
-  value = azurerm_kubernetes_cluster.aks-vantiq.default_node_pool[0].node_count
+  value = var.vantiq_node_pool_node_count == 0 ? 0 : azurerm_kubernetes_cluster_node_pool.vantiqnp[0].node_count
 }
 
 output "aks_nodegroup_mongodb_vm_size" {
@@ -71,11 +71,11 @@ output "aks_nodegroup_mongodb_node_count" {
 }
 
 output "aks_nodegroup_keycloak_vm_size" {
-  value = var.keycloak_node_pool_node_count == 0 ? "N/A" : azurerm_kubernetes_cluster_node_pool.keycloaknp[0].vm_size
+  value = azurerm_kubernetes_cluster.aks-vantiq.default_node_pool[0].vm_size
 }
 
 output "aks_nodegroup_keycloak_node_count" {
-  value = var.keycloak_node_pool_node_count == 0 ? 0 : azurerm_kubernetes_cluster_node_pool.keycloaknp[0].node_count
+  value = azurerm_kubernetes_cluster.aks-vantiq.default_node_pool[0].node_count
 }
 
 output "aks_nodegroup_grafana_vm_size" {

--- a/vantiq-cloud-infra-operations/terraform_azure/readme.md
+++ b/vantiq-cloud-infra-operations/terraform_azure/readme.md
@@ -177,6 +177,7 @@ Vantiq Public Cloudを構成するためのAzure Infrastructure構成。
   - `service_cidr` - Service用に確保するcidr
   - `admin_username` - AKSワーカーノードのユーザー名
   - `ssh_key` - AKSワーカーノードアクセス用のpublic keyのパス
+  - `availability_zones` - 各Nodepool共通のワーカーノードを作成するzoneのリストでenv-devの場合nodepoolのVMが１台のみのため、特定のzoneにデプロイするために指定する
   - `xxx_node_pool_vm_size`: `vantiq`, `mongo`, `userdb`, `grafana`, `keycloak`, `metrics`の各nodepoolのVMサイズを指定する
   - `xxx_node_pool_node_count`: `vantiq`, `mongo`, `userdb`, `grafana`, `keycloak`, `metrics`の各nodepoolのVM数を指定する
 


### PR DESCRIPTION
- AKSのSystem node poolをvantiq から shared(keycloak)に変更
- env-devのnodepoolのavailability_zonesのリストを1のみに変更
=>readmeにパラメータ追加
- kubernetesバージョンがサポート外のもののため、現時点でサポートしている最も古いバージョンの1.22.11に変更

※env-devでavailability_zonesを3のみ指定し、作成した場合のNode一覧
```sh
$ kubectl get no -o wide -L failure-domain.beta.kubernetes.io/zone -L  kubernetes.azure.com/mode
NAME                                 STATUS   ROLES   AGE   VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION     CONTAINER-RUNTIME             ZONE          MODE
aks-grafananp-17023299-vmss000000    Ready    agent   12m   v1.22.11   10.1.48.93    <none>        Ubuntu 18.04.6 LTS   5.4.0-1089-azure   containerd://1.5.11+azure-2   japaneast-3   user
aks-keycloaknp-37628198-vmss000000   Ready    agent   16m   v1.22.11   10.1.48.5     <none>        Ubuntu 18.04.6 LTS   5.4.0-1089-azure   containerd://1.5.11+azure-2   japaneast-3   system
aks-mongodbnp-30634881-vmss000000    Ready    agent   12m   v1.22.11   10.1.48.35    <none>        Ubuntu 18.04.6 LTS   5.4.0-1089-azure   containerd://1.5.11+azure-2   japaneast-3   user
aks-vantiqnp-40433525-vmss000000     Ready    agent   12m   v1.22.11   10.1.48.64    <none>        Ubuntu 18.04.6 LTS   5.4.0-1089-azure   containerd://1.5.11+azure-2   japaneast-3   user
```
