### PR TITLE
fixed single_az_node_list

### DIFF
--- a/vantiq-cloud-infra-operations/terraform_aws/new/env-prod/constants.tf
+++ b/vantiq-cloud-infra-operations/terraform_aws/new/env-prod/constants.tf
@@ -151,7 +151,7 @@ locals {
         node_workload_label = "orgCompute"
       },
     }
-    single_az_node_list          = ["VANTIQ", "MongoDB", "keycloak", "grafana", "metrics", "ai_assistant"]
+    single_az_node_list          = ["grafana"]
     sg_ids_allowed_ssh_to_worker = []
   }
   eks_addon_config = {

--- a/vantiq-cloud-infra-operations/terraform_aws/new/env-template/constants.tf
+++ b/vantiq-cloud-infra-operations/terraform_aws/new/env-template/constants.tf
@@ -151,7 +151,7 @@ locals {
         node_workload_label = "orgCompute"
       },
     }
-    single_az_node_list          = ["VANTIQ", "MongoDB", "keycloak", "grafana", "metrics", "ai_assistant"]
+    single_az_node_list          = ["grafana"]
     sg_ids_allowed_ssh_to_worker = []
   }
   eks_addon_config = {


### PR DESCRIPTION
`single_az_node_list` `prd`と`template`のシングルAZノードグループリストから下記ノードグループを削除する
- VANTIQ
- MongoDB
- keycloak
- metrics
- ai_assistant