### PR TITLE
Vantiq_v1.39バージョンアップに伴うdeploy.yamlの変更点追記

### DIFF
--- a/vantiq-platform-operations/docs/jp/deploy_yaml_config.md
+++ b/vantiq-platform-operations/docs/jp/deploy_yaml_config.md
@@ -262,7 +262,17 @@ keycloak:
     hostname: <PostgreSQL Endpoint>
 ```
 ※system version 3.13以前では`keycloak.persistence.dbHost`であった。  
-
+  
+また、keycloakの初期管理ユーザーが`keycloak`から`admin`に変わったため、以下のようにユーザー名を明示的に指定する必要がある。
+```yaml
+keycloak:
+  username: admin
+```
+```yaml
+vantiq:
+  keycloak:
+    username: admin
+```
 ## vantiq r1.37以降のMongoDBバージョン
 r1.37以降では、mongoDBのバージョンを5.0.18に指定する必要がある。
 ```yaml

--- a/vantiq-platform-operations/docs/jp/vantiq-maintenance.md
+++ b/vantiq-platform-operations/docs/jp/vantiq-maintenance.md
@@ -118,7 +118,10 @@ Vantiq の Minor Version がインクレメントされるアップグレード�
 Enhancement のための DB Schema 拡張を伴うため、ダウンタイムが必要になる。
 1. 顧客の DTC にアップグレードに伴うサービス停止をアナウンスする (顧客 DTC はサービス停止による影響回避を社内で調整する)。
 1. 最新の k8sdeploy_tools に更新する。k8sdeploy_tools のルートで `git pull` を実行する。
-1. `deploy.yaml` の変更を行う (`vantiq.image.tag`)。
+1. `deploy.yaml` の変更を行う (`vantiq.image.tag`)。※  
+  ※1.38→1.39バージョンアップの場合は、以下の設定変更も実施する。  
+    - `keycloak.username`の追加。設定値は`admin`。
+    - `keycloak.persistence.dbHost`を`keycloak.database.hostname`に変更。
 1. `cluster.properties` の `vantiq_system_release` を vantiq バージョンをサポートするものに変更する。バージョンアップに伴いその他のパラメーターが変更が必要な場合もある。
 1. `cluster.properties` に変更があった場合、設定の更新を反映する。  
 `./gradlew -Pcluster=<クラスタ名> setupCluster`  


### PR DESCRIPTION
Vantiqのv1.39インストール/バージョンアップに伴うdeploy.yamlの追加変更点を以下の手順書に追記。

■vantiq-platform-operations/docs/jp/deploy_yaml_config.md
・「system version 3.14 以降のkeycloakパラメータ」項目に、keycloakの管理ユーザー名変更に伴うdeploy.yamlの追加変更点を追記。

■vantiq-platform-operations/docs/jp/vantiq-maintenance.md
・Vantiqマイナーバージョンアップ手順に、1.38→1.39バージョンアップ時のdeploy.yamlの追加変更点を追記。